### PR TITLE
Implement NodeContainer format

### DIFF
--- a/libgame.UnitTests/FileFormat/NodeContainerFormatTests.cs
+++ b/libgame.UnitTests/FileFormat/NodeContainerFormatTests.cs
@@ -1,0 +1,148 @@
+﻿//
+// NodeContainerFormatTests.cs
+//
+// Author:
+//       Benito Palacios Sánchez <benito356@gmail.com>
+//
+// Copyright (c) 2016 Benito Palacios Sánchez
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace Libgame.UnitTests.FileFormat
+{
+    using System;
+    using System.Collections.Generic;
+    using Libgame.FileSystem;
+    using Libgame.FileFormat;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class NodeContainerFormatTests : BaseGeneralTests<NodeContainerFormat>
+    {
+        [Test]
+        public void CorrectName()
+        {
+            NameIsCorrect("libgame", "nodecontainer");
+        }
+
+        [Test]
+        public void ConstructorSetProperties()
+        {
+            NodeContainerFormat format = new NodeContainerFormat();
+            Assert.IsNotNull(format.Children);
+            Assert.IsEmpty(format.Children);
+        }
+
+        [Test]
+        public void AddNewChildren()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+
+            Node child1 = new Node("Child1");
+            format.Add(child1);
+            Assert.AreEqual(1, format.Children.Count);
+            Assert.AreSame(child1, format.Children[0]);
+
+            Node child2 = new Node("Child2");
+            format.Add(child2);
+            Assert.AreEqual(2, format.Children.Count);
+            Assert.AreSame(child2, format.Children[1]);
+        }
+
+        [Test]
+        public void ReplaceChildren()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+
+            Node child = new Node("Child1");
+            format.Add(child);
+            Assert.AreEqual(1, format.Children.Count);
+            Assert.AreSame(child, format.Children[0]);
+
+            Node childSameName = new Node("Child1");
+            format.Add(childSameName);
+            Assert.AreEqual(1, format.Children.Count);
+            Assert.AreNotSame(child, format.Children[0]);
+            Assert.AreSame(childSameName, format.Children[0]);
+        }
+
+        [Test]
+        public void AddListOfNodes()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+
+            List<Node> children = new List<Node>();
+            children.Add(new Node("Child1"));
+            children.Add(new Node("Child2"));
+            children.Add(new Node("Child3"));
+            
+            format.Add(children);
+            Assert.AreEqual(3, format.Children.Count);
+            Assert.AreSame(children[0], format.Children[0]);
+            Assert.AreSame(children[1], format.Children[1]);
+            Assert.AreSame(children[2], format.Children[2]);
+        }
+
+        [Test]
+        public void AddListOfNodesNull()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+            Assert.Throws<ArgumentNullException>(() => format.Add((List<Node>)null));
+        }
+
+        [Test]
+        public void AddNullNode()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+            Assert.Throws<ArgumentNullException>(() => format.Add((Node)null));
+        }
+
+        [Test]
+        public void AddAndGetNodeByName()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+            Node child = new Node("Child1");
+            format.Add(child);
+            Assert.AreSame(child, format.Children["Child1"]);
+        }
+
+        [Test]
+        public void AddAfterDisposeThrowException()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+            format.Dispose();
+            Node child = new Node("Child");
+            Assert.Throws<ObjectDisposedException>(() => format.Add(child));
+        }
+
+        [Test]
+        public void AddListOfNodesAfterDisposeThrowException()
+        {
+            NodeContainerFormat format = CreateDummyFormat();
+            format.Dispose();
+            List<Node> children = new List<Node>();
+            children.Add(new Node("Child"));
+            Assert.Throws<ObjectDisposedException>(() => format.Add(children));
+        }
+
+        protected override NodeContainerFormat CreateDummyFormat()
+        {
+            return new NodeContainerFormat();
+        }
+    }
+}

--- a/libgame.UnitTests/FileSystem/NodeTests.cs
+++ b/libgame.UnitTests/FileSystem/NodeTests.cs
@@ -247,6 +247,32 @@ namespace Libgame.UnitTests.FileSystem
             Assert.IsTrue(dummyFormat.Disposed);
         }
 
+        [Test]
+        public void SetContainerFormatAddChildren()
+        {
+            Node node = new Node("MyTest");
+            NodeContainerFormat format = new NodeContainerFormat();
+            format.Add(new Node("Child"));
+            node.Format = format;
+
+            Assert.AreEqual(1, node.Children.Count);
+            Assert.AreSame(format.Children[0], node.Children[0]);
+        }
+
+        [Test]
+        public void SetFromContainerToDifferentCleanChildren()
+        {
+            Node node = new Node("mytest");
+            NodeContainerFormat format = new NodeContainerFormat();
+            format.Add(new Node("Child"));
+            node.Format = format;
+            Assert.IsNotEmpty(node.Children);
+
+            StringFormatTest newFormat = new StringFormatTest("3");
+            node.Format = newFormat;
+            Assert.IsEmpty(node.Children);
+        }
+
         public class PrivateConverter : 
             IConverter<StringFormatTest, IntFormatTest>,
             IConverter<IntFormatTest, StringFormatTest>

--- a/libgame.UnitTests/FileSystem/NodeTests.cs
+++ b/libgame.UnitTests/FileSystem/NodeTests.cs
@@ -273,6 +273,30 @@ namespace Libgame.UnitTests.FileSystem
             Assert.IsEmpty(node.Children);
         }
 
+        [Test]
+        public void IsContainerIfFormatNodeContainer()
+        {
+            NodeContainerFormat format = new NodeContainerFormat();
+            Node node = new Node("NodeTest", format);
+            Assert.IsTrue(node.IsContainer);
+        }
+
+        [Test]
+        public void IsNotContainerForDifferentFormat()
+        {
+            StringFormatTest format = new StringFormatTest("3");
+            Node node = new Node("NodeTest", format);
+            Assert.IsFalse(node.IsContainer);
+        }
+
+        [Test]
+        public void IsContainerIfFormatDerivedFromNodeContainer()
+        {
+            MyContainer format = new MyContainer();
+            Node node = new Node("MyTest", format);
+            Assert.IsTrue(node.IsContainer);
+        }
+
         public class PrivateConverter : 
             IConverter<StringFormatTest, IntFormatTest>,
             IConverter<IntFormatTest, StringFormatTest>
@@ -286,6 +310,10 @@ namespace Libgame.UnitTests.FileSystem
             {
                 return new StringFormatTest(test.Value.ToString());
             }
+        }
+
+        class MyContainer : NodeContainerFormat
+        {
         }
     }
 }

--- a/libgame.UnitTests/FileSystem/NodeTests.cs
+++ b/libgame.UnitTests/FileSystem/NodeTests.cs
@@ -297,6 +297,15 @@ namespace Libgame.UnitTests.FileSystem
             Assert.IsTrue(node.IsContainer);
         }
 
+        [Test]
+        public void SetFormatThrowExceptionIfDisposed()
+        {
+            Node node = new Node("MyTest");
+            node.Dispose();
+            StringFormatTest format = new StringFormatTest("3");
+            Assert.Throws<ObjectDisposedException>(() => node.Format = format);
+        }
+
         public class PrivateConverter : 
             IConverter<StringFormatTest, IntFormatTest>,
             IConverter<IntFormatTest, StringFormatTest>

--- a/libgame.UnitTests/libgame.UnitTests.csproj
+++ b/libgame.UnitTests/libgame.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="FileSystem\NodeFactoryTests.cs" />
     <Compile Include="FileFormat\BinaryFormatTests.cs" />
     <Compile Include="FileFormat\BaseGeneralTests.cs" />
+    <Compile Include="FileFormat\NodeContainerFormatTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libgame\libgame.csproj">

--- a/libgame/FileFormat/NodeContainerFormat.cs
+++ b/libgame/FileFormat/NodeContainerFormat.cs
@@ -25,13 +25,83 @@
 // THE SOFTWARE.
 namespace Libgame.FileFormat
 {
+    using System;
+    using System.Collections.Generic;
+    using FileSystem;
     using Mono.Addins;
 
+    /// <summary>
+    /// Node container format for unpack / pack files.
+    /// </summary>
     [Extension]
     public class NodeContainerFormat : Format
     {
+        readonly Node root;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NodeContainerFormat"/> class.
+        /// </summary>
+        public NodeContainerFormat()
+        {
+            root = new Node("NodeContainerRoot");
+            Children = root.Children;
+        }
+
+        /// <summary>
+        /// Gets the format name.
+        /// </summary>
+        /// <value>The format name.</value>
         public override string Name {
             get { return "libgame.nodecontainer"; }
+        }
+
+        /// <summary>
+        /// Gets a read-only list of children nodes.
+        /// </summary>
+        /// <value>The list of children.</value>
+        public NavegableNodeCollection<Node> Children {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Add a node.
+        /// </summary>
+        /// <remarks>
+        /// Updates the parent of the child node to match this instance.
+        /// If the node already contains a child with the same name it will be replaced.
+        /// Otherwise the node is added.
+        /// </remarks>
+        /// <param name="node">Node to add.</param>
+        public void Add(Node node)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NodeContainerFormat));
+
+            root.Add(node);
+        }
+
+        /// <summary>
+        /// Add a list of nodes.
+        /// </summary>
+        /// <param name="nodes">List of nodes to add.</param>
+        public void Add(IEnumerable<Node> nodes)
+        {
+            if (Disposed)
+                throw new ObjectDisposedException(nameof(NodeContainerFormat));
+
+            if (nodes == null)
+                throw new ArgumentNullException(nameof(nodes));
+
+            foreach (Node node in nodes)
+                Add(node);
+        }
+
+        protected override void Dispose(bool freeManagedResourcesAlso)
+        {
+            base.Dispose(freeManagedResourcesAlso);
+            if (freeManagedResourcesAlso)
+                root.Dispose();
         }
     }
 }

--- a/libgame/FileSystem/Node.cs
+++ b/libgame/FileSystem/Node.cs
@@ -28,6 +28,8 @@ namespace Libgame.FileSystem
     /// </summary>
     public class Node : NavegableNode<Node>, IDisposable
     {
+        Format format;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Node"/> class.
         /// </summary>
@@ -72,8 +74,18 @@ namespace Libgame.FileSystem
         /// </summary>
         /// <value>The current format.</value>
         public Format Format {
-            get;
-            set;
+            get { return format; }
+            set {
+                // If it was a container, clean children
+                if (IsContainer)
+                    RemoveChildren();
+
+                format = value;
+
+                // If now it's a container, add its children
+                if (IsContainer)
+                    AddContainerChildren();
+            }
         }
 
         /// <summary>
@@ -113,6 +125,7 @@ namespace Libgame.FileSystem
                 Format.Dispose();
 
             Format = newFormat;
+
             return this;
         }
 
@@ -156,6 +169,12 @@ namespace Libgame.FileSystem
 
             if (freeManagedResourcesAlso)
                 Format?.Dispose();
+        }
+
+        void AddContainerChildren()
+        {
+            RemoveChildren();
+            Add((Format as NodeContainerFormat).Children);
         }
     }
 }

--- a/libgame/FileSystem/Node.cs
+++ b/libgame/FileSystem/Node.cs
@@ -43,11 +43,11 @@ namespace Libgame.FileSystem
         /// Initializes a new instance of the <see cref="Node"/> class.
         /// </summary>
         /// <param name="name">Node name.</param>
-        /// <param name="format">Node format.</param>
-        public Node(string name, Format format)
+        /// <param name="initialFormat">Node format.</param>
+        public Node(string name, Format initialFormat)
             : this(name)
         {
-            Format = format;
+            Format = initialFormat;
         }
 
         /// <summary>
@@ -74,8 +74,14 @@ namespace Libgame.FileSystem
         /// </summary>
         /// <value>The current format.</value>
         public Format Format {
-            get { return format; }
+            get {
+                return format;
+            }
+
             set {
+                if (Disposed)
+                    throw new ObjectDisposedException(nameof(Node));
+
                 // If it was a container, clean children
                 if (IsContainer)
                     RemoveChildren();
@@ -168,7 +174,7 @@ namespace Libgame.FileSystem
             Disposed = true;
 
             if (freeManagedResourcesAlso)
-                Format?.Dispose();
+                format?.Dispose();
         }
 
         void AddContainerChildren()


### PR DESCRIPTION
The `NodeContainerFormat` will handle formats that contains a tree of Nodes. The goal is to be able to convert from a binary pack format to a node tree. The Node format is able to detect this and automatically add its nodes.

Fixes #4 